### PR TITLE
VID-7463: Support multiple ID3 events per audio packet

### DIFF
--- a/include/gpac/mpd.h
+++ b/include/gpac/mpd.h
@@ -732,6 +732,8 @@ typedef struct
 	GF_List *viewpoint;
 	/*! content component descriptor list if any*/
 	GF_List *content_component;
+    /*! inband streams events */
+    GF_List *inband_event;
 
 	/*! base URL (alternate location) list if any*/
 	GF_List *base_URLs;
@@ -765,6 +767,13 @@ typedef struct
 	/*target fragment duration*/
 	Double hls_ll_target_frag_dur;
 } GF_MPD_AdaptationSet;
+
+typedef struct {
+    /* Scheme ID Uri of the inband event */
+    char *scheme_id_uri;
+    /* Value of the inband event */
+    char *value;
+} GF_MPD_Inband_Event;
 
 /*! MPD offering type*/
 typedef enum {

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -2847,7 +2847,7 @@ static void dasher_set_inband_event(GF_DashStream *ds) {
 	if(ds->stream_type == GF_STREAM_AUDIO) {
 		GF_SAFEALLOC(custom_event, GF_MPD_Inband_Event);
 		custom_event->scheme_id_uri = gf_strdup("https://aomedia.org/emsg/ID3");
-		custom_event->value = gf_strdup("www.geniussports.com:id3:v1");
+		custom_event->value = gf_strdup("https://aomedia.org/emsg/ID3");
 		GF_LOG(GF_LOG_DEBUG, GF_LOG_DASH, ("[Dasher] insertign in band event with scheme: %s and value: %s\n", custom_event->scheme_id_uri,custom_event->value))
 		GF_SAFEALLOC(nielsen_event, GF_MPD_Inband_Event);
 		nielsen_event->scheme_id_uri = gf_strdup("https://aomedia.org/emsg/ID3");

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -1616,8 +1616,8 @@ static GF_Err dasher_configure_pid(GF_Filter *filter, GF_FilterPid *pid, Bool is
 		CHECK_PROP_STR(GF_PROP_PID_XLINK, ds->xlink, GF_EOS)
 	}
 
-     if (ctx->do_index || ctx->from_index) {
 
+	if (ctx->do_index || ctx->from_index) {
 		if (!ds->template && ctx->def_template) {
 			p = gf_filter_pid_get_property_str(ds->ipid, "idx_template");
 			if (p) {

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -2847,10 +2847,11 @@ static void dasher_set_inband_event(GF_DashStream *ds) {
 		GF_SAFEALLOC(custom_event, GF_MPD_Inband_Event);
 		custom_event->scheme_id_uri = gf_strdup("https://aomedia.org/emsg/ID3");
 		custom_event->value = gf_strdup("www.geniussports.com:id3:v1");
+		GF_LOG(GF_LOG_DEBUG, GF_LOG_DASH, ("[Dasher] insertign in band event with scheme: %s and value: %s\n", custom_event->scheme_id_uri,custom_event->value))
 		GF_SAFEALLOC(nielsen_event, GF_MPD_Inband_Event);
 		nielsen_event->scheme_id_uri = gf_strdup("https://aomedia.org/emsg/ID3");
 		nielsen_event->value = gf_strdup("www.nielsen.com:id3:v1");
-		GF_LOG(GF_LOG_WARNING, GF_LOG_DASH, ("[Dasher] %s\n", nielsen_event->scheme_id_uri))
+		GF_LOG(GF_LOG_DEBUG, GF_LOG_DASH, ("[Dasher] insertign in band event with scheme: %s and value: %s\n", nielsen_event->scheme_id_uri,nielsen_event->value))
 		gf_list_add(ds->set->inband_event, nielsen_event);
 		gf_list_add(ds->set->inband_event, custom_event);
 	}

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -1617,6 +1617,7 @@ static GF_Err dasher_configure_pid(GF_Filter *filter, GF_FilterPid *pid, Bool is
 	}
 
      if (ctx->do_index || ctx->from_index) {
+
 		if (!ds->template && ctx->def_template) {
 			p = gf_filter_pid_get_property_str(ds->ipid, "idx_template");
 			if (p) {
@@ -3983,7 +3984,6 @@ static void dasher_setup_sources(GF_Filter *filter, GF_DasherCtx *ctx, GF_MPD_Ad
 
 		//remove representations for streams muxed with others, but still open the output
 		if (ds->muxed_base) {
-			GF_LOG(GF_LOG_WARNING, GF_LOG_DASH, ("[Dasher] set_up source\n"));
 			GF_DashStream *ds_set = set->udta;
 			gf_list_rem(set->representations, i);
 			i--;

--- a/src/filters/dmx_m2ts.c
+++ b/src/filters/dmx_m2ts.c
@@ -44,7 +44,7 @@ static const u8 NIELSEN_ID3_TAG_PREFIX[] = {0x49, 0x44, 0x33, 0x04, 0x00, 0x20,
 
 static const char *ID3_PROP_SCHEME_URI = "https://aomedia.org/emsg/ID3";
 static const char *ID3_PROP_VALUE_URI_NIELSEN = "www.nielsen.com:id3:v1";
-static const char *ID3_PROP_VALUE_URI_DEFAULT = "https://aomedia.org/emsg/ID3";
+static const char *ID3_PROP_VALUE_URI_DEFAULT = "www.geniussports.com:id3:v1";
 
 typedef struct {
 	char *fragment;

--- a/src/filters/dmx_m2ts.c
+++ b/src/filters/dmx_m2ts.c
@@ -44,7 +44,7 @@ static const u8 NIELSEN_ID3_TAG_PREFIX[] = {0x49, 0x44, 0x33, 0x04, 0x00, 0x20,
 
 static const char *ID3_PROP_SCHEME_URI = "https://aomedia.org/emsg/ID3";
 static const char *ID3_PROP_VALUE_URI_NIELSEN = "www.nielsen.com:id3:v1";
-static const char *ID3_PROP_VALUE_URI_DEFAULT = "www.geniussports.com:id3:v1";
+static const char *ID3_PROP_VALUE_URI_DEFAULT = "https://aomedia.org/emsg/ID3";
 
 typedef struct {
 	char *fragment;

--- a/src/filters/dmx_m2ts.c
+++ b/src/filters/dmx_m2ts.c
@@ -33,6 +33,19 @@
 #include <gpac/thread.h>
 #include <gpac/internal/media_dev.h>
 
+// First 36 bytes of a Nielsen ID3 tag: "ID3\x04\x00 \x00\x00\x02\x05PRIV\x00\x00\x01{\x00\x00www.nielsen.com/"
+static const u32 NIELSEN_ID3_TAG_PREFIX_LEN = 36;
+static const u8 NIELSEN_ID3_TAG_PREFIX[] = {0x49, 0x44, 0x33, 0x04, 0x00, 0x20,
+											0x00, 0x00, 0x02, 0x05, 0x50, 0x52,
+											0x49, 0x56, 0x00, 0x00, 0x01, 0x7B,
+											0x00, 0x00, 0x77, 0x77, 0x77, 0x2E,
+											0x6E, 0x69, 0x65, 0x6C, 0x73, 0x65,
+											0x6E, 0x2E, 0x63, 0x6F, 0x6D, 0x2F};
+
+static const char *ID3_PROP_SCHEME_URI = "https://aomedia.org/emsg/ID3";
+static const char *ID3_PROP_VALUE_URI_NIELSEN = "www.nielsen.com:id3:v1";
+static const char *ID3_PROP_VALUE_URI_DEFAULT = "https://aomedia.org/emsg/ID3";
+
 typedef struct {
 	char *fragment;
 	u32 id;
@@ -1190,11 +1203,34 @@ static void m2tsdmx_on_event(GF_M2TS_Demuxer *ts, u32 evt_type, void *param)
 			GF_SAFEALLOC(t, GF_M2TS_Prop);
 			if (!t) break;
 			t->type = M2TS_ID3;
+
+			u32 value_uri_len = 0;
+			const char *value_uri = NULL;
+
+			// test if the data is a Nielsen ID3 tag
+			if (memcmp(pck->data, NIELSEN_ID3_TAG_PREFIX, NIELSEN_ID3_TAG_PREFIX_LEN) == 0)
+			{
+				value_uri_len = strlen(ID3_PROP_VALUE_URI_NIELSEN) + 1; // plus null character
+				value_uri = ID3_PROP_VALUE_URI_NIELSEN;
+			}
+			else
+			{
+				value_uri_len = strlen(ID3_PROP_VALUE_URI_DEFAULT) + 1; // plus null character
+				value_uri = ID3_PROP_VALUE_URI_DEFAULT;
+			}
+
+			const u32 id3_scheme_uri_len = (u32)strlen(ID3_PROP_SCHEME_URI) + 1; // plus null character
+
 			bs = gf_bs_new(NULL, 0, GF_BITSTREAM_WRITE);
-			gf_bs_write_u32(bs, 90000);                     // timescale
-			gf_bs_write_u64(bs, pck->PTS);                  // pts
-			gf_bs_write_u32(bs, pck->data_len);				// data length (bytes)
-			gf_bs_write_data(bs, pck->data, pck->data_len); // data
+			gf_bs_write_u32(bs, 90000);												   // timescale
+			gf_bs_write_u64(bs, pck->PTS);											   // pts
+			gf_bs_write_u32(bs, id3_scheme_uri_len);								   // scheme URI length
+			gf_bs_write_data(bs, (const u8 *)ID3_PROP_SCHEME_URI, id3_scheme_uri_len); // scheme URI
+			gf_bs_write_u32(bs, value_uri_len);										   // value URI length
+			gf_bs_write_data(bs, (const u8 *)value_uri, value_uri_len);				   // value URI
+			gf_bs_write_u32(bs, pck->data_len);										   // data length (bytes)
+			gf_bs_write_data(bs, pck->data, pck->data_len);							   // data
+
 			gf_bs_get_content(bs, &t->data, &t->len);
 			gf_bs_del(bs);
 

--- a/src/filters/mux_isom.c
+++ b/src/filters/mux_isom.c
@@ -7759,7 +7759,8 @@ static GF_Err mp4_mux_initialize(GF_Filter *filter)
 	GF_MP4MuxCtx *ctx = gf_filter_get_udta(filter);
 	gf_filter_set_max_extra_input_pids(filter, -1);
 	ctx->filter = filter;
-	ctx->id3_id_sequence=0;
+	time_t current_time =time(NULL);
+	ctx->id3_id_sequence=(long)current_time;
 #ifdef GPAC_DISABLE_ISOM_FRAGMENTS
 	if (ctx->store>=MP4MX_MODE_FRAG) {
 		GF_LOG(GF_LOG_ERROR, GF_LOG_CONTAINER, ("[MP4Mux] Cannot use fragmented mode, disabled in build\n"));

--- a/src/filters/mux_isom.c
+++ b/src/filters/mux_isom.c
@@ -416,6 +416,7 @@ typedef struct
 	GF_List *ref_pcks;
 	//create id3 secuence
 	u32 id3_id_sequence;
+	GF_PropertyValue *last_id3_processed;
 } GF_MP4MuxCtx;
 
 static void mp4_mux_update_init_edit(GF_MP4MuxCtx *ctx, TrackWriter *tkw, u64 min_ts_service, Bool skip_adjust);
@@ -6637,8 +6638,12 @@ static GF_Err mp4_mux_process_fragmented(GF_MP4MuxCtx *ctx)
 			//push ID3 packet properties as emsg
 			const GF_PropertyValue *emsg = gf_filter_pck_get_property_str(pck, "id3");
 			if (emsg && (emsg->type == GF_PROP_DATA) && emsg->value.data.ptr) {
-				mp4_process_id3(ctx->file->moof, emsg, ctx->id3_id_sequence);
-				ctx->id3_id_sequence = ctx->id3_id_sequence + 1;
+				if (emsg != ctx->last_id3_processed) {
+					mp4_process_id3(ctx->file->moof, emsg, ctx->id3_id_sequence);
+					ctx->id3_id_sequence = ctx->id3_id_sequence + 1;
+				}
+
+				ctx->last_id3_processed = emsg;
 			}
 
 			if (ctx->dash_mode) {

--- a/src/filters/mux_isom.c
+++ b/src/filters/mux_isom.c
@@ -6494,7 +6494,6 @@ static GF_Err mp4_mux_process_fragmented(GF_MP4MuxCtx *ctx)
 	nb_eos=0;
 	nb_done = 0;
 	nb_suspended = 0;
-	ctx->id3_id_sequence=0;
 	for (i=0; i<count; i++) {
 		u64 cts, dts, ncts;
 		TrackWriter *tkw = gf_list_get(ctx->tracks, i);
@@ -7760,6 +7759,7 @@ static GF_Err mp4_mux_initialize(GF_Filter *filter)
 	GF_MP4MuxCtx *ctx = gf_filter_get_udta(filter);
 	gf_filter_set_max_extra_input_pids(filter, -1);
 	ctx->filter = filter;
+	ctx->id3_id_sequence=0;
 #ifdef GPAC_DISABLE_ISOM_FRAGMENTS
 	if (ctx->store>=MP4MX_MODE_FRAG) {
 		GF_LOG(GF_LOG_ERROR, GF_LOG_CONTAINER, ("[MP4Mux] Cannot use fragmented mode, disabled in build\n"));

--- a/src/filters/mux_isom.c
+++ b/src/filters/mux_isom.c
@@ -6397,7 +6397,7 @@ GF_Err mp4mx_reload_output(GF_MP4MuxCtx *ctx)
 }
 
 #ifndef GPAC_DISABLE_ISOM_FRAGMENTS
-static void mp4_process_id3(GF_MovieFragmentBox *moof, const GF_PropertyValue *emsg_prop, u32 id_secuence)
+static void mp4_process_id3(GF_MovieFragmentBox *moof, const GF_PropertyValue *emsg_prop, u32 id_sequence)
 {
 	GF_BitStream *bs = gf_bs_new(emsg_prop->value.data.ptr, emsg_prop->value.data.size, GF_BITSTREAM_READ);
 	GF_EventMessageBox *emsg = (GF_EventMessageBox *)gf_isom_box_new(GF_ISOM_BOX_TYPE_EMSG);
@@ -6429,7 +6429,7 @@ static void mp4_process_id3(GF_MovieFragmentBox *moof, const GF_PropertyValue *e
 	emsg->timescale = timescale;
 	emsg->presentation_time_delta = pts_delta;
 	emsg->event_duration = 0xFFFFFFFF;
-	emsg->event_id = id_secuence;
+	emsg->event_id = id_sequence;
 	emsg->scheme_id_uri = gf_strdup(scheme_uri);
 	emsg->value = gf_strdup(value_uri);
 

--- a/src/filters/mux_isom.c
+++ b/src/filters/mux_isom.c
@@ -415,7 +415,7 @@ typedef struct
 
 	GF_List *ref_pcks;
 	//create id3 secuence
-	u32 id3_id_secuence;
+	u32 id3_id_sequence;
 } GF_MP4MuxCtx;
 
 static void mp4_mux_update_init_edit(GF_MP4MuxCtx *ctx, TrackWriter *tkw, u64 min_ts_service, Bool skip_adjust);
@@ -6494,7 +6494,7 @@ static GF_Err mp4_mux_process_fragmented(GF_MP4MuxCtx *ctx)
 	nb_eos=0;
 	nb_done = 0;
 	nb_suspended = 0;
-	ctx->id3_id_secuence=0;
+	ctx->id3_id_sequence=0;
 	for (i=0; i<count; i++) {
 		u64 cts, dts, ncts;
 		TrackWriter *tkw = gf_list_get(ctx->tracks, i);
@@ -6638,8 +6638,8 @@ static GF_Err mp4_mux_process_fragmented(GF_MP4MuxCtx *ctx)
 			//push ID3 packet properties as emsg
 			const GF_PropertyValue *emsg = gf_filter_pck_get_property_str(pck, "id3");
 			if (emsg && (emsg->type == GF_PROP_DATA) && emsg->value.data.ptr) {
-				mp4_process_id3(ctx->file->moof, emsg, ctx->id3_id_secuence);
-				ctx->id3_id_secuence = ctx->id3_id_secuence + 1;
+				mp4_process_id3(ctx->file->moof, emsg, ctx->id3_id_sequence);
+				ctx->id3_id_sequence = ctx->id3_id_sequence + 1;
 			}
 
 			if (ctx->dash_mode) {

--- a/src/filters/mux_isom.c
+++ b/src/filters/mux_isom.c
@@ -414,6 +414,8 @@ typedef struct
 	Bool has_chap_tracks;
 
 	GF_List *ref_pcks;
+	//create id3 secuence
+	u32 id3_id_secuence;
 } GF_MP4MuxCtx;
 
 static void mp4_mux_update_init_edit(GF_MP4MuxCtx *ctx, TrackWriter *tkw, u64 min_ts_service, Bool skip_adjust);
@@ -6395,7 +6397,7 @@ GF_Err mp4mx_reload_output(GF_MP4MuxCtx *ctx)
 }
 
 #ifndef GPAC_DISABLE_ISOM_FRAGMENTS
-static void mp4_process_id3(GF_MovieFragmentBox *moof, const GF_PropertyValue *emsg_prop)
+static void mp4_process_id3(GF_MovieFragmentBox *moof, const GF_PropertyValue *emsg_prop, u32 id_secuence)
 {
 	GF_BitStream *bs = gf_bs_new(emsg_prop->value.data.ptr, emsg_prop->value.data.size, GF_BITSTREAM_READ);
 	GF_EventMessageBox *emsg = (GF_EventMessageBox *)gf_isom_box_new(GF_ISOM_BOX_TYPE_EMSG);
@@ -6427,7 +6429,7 @@ static void mp4_process_id3(GF_MovieFragmentBox *moof, const GF_PropertyValue *e
 	emsg->timescale = timescale;
 	emsg->presentation_time_delta = pts_delta;
 	emsg->event_duration = 0xFFFFFFFF;
-	emsg->event_id = 0;
+	emsg->event_id = id_secuence;
 	emsg->scheme_id_uri = gf_strdup(scheme_uri);
 	emsg->value = gf_strdup(value_uri);
 
@@ -6492,6 +6494,7 @@ static GF_Err mp4_mux_process_fragmented(GF_MP4MuxCtx *ctx)
 	nb_eos=0;
 	nb_done = 0;
 	nb_suspended = 0;
+	ctx->id3_id_secuence=0;
 	for (i=0; i<count; i++) {
 		u64 cts, dts, ncts;
 		TrackWriter *tkw = gf_list_get(ctx->tracks, i);
@@ -6635,7 +6638,8 @@ static GF_Err mp4_mux_process_fragmented(GF_MP4MuxCtx *ctx)
 			//push ID3 packet properties as emsg
 			const GF_PropertyValue *emsg = gf_filter_pck_get_property_str(pck, "id3");
 			if (emsg && (emsg->type == GF_PROP_DATA) && emsg->value.data.ptr) {
-				mp4_process_id3(ctx->file->moof, emsg);
+				mp4_process_id3(ctx->file->moof, emsg, ctx->id3_id_secuence);
+				ctx->id3_id_secuence = ctx->id3_id_secuence + 1;
 			}
 
 			if (ctx->dash_mode) {

--- a/src/media_tools/mpd.c
+++ b/src/media_tools/mpd.c
@@ -1248,6 +1248,7 @@ void gf_mpd_content_component_free(void *item)
 
 void gf_mpd_inband_event_free(void *item) {
     GF_MPD_Inband_Event *inband_event_desc = (GF_MPD_Inband_Event *) item;
+	GF_LOG(GF_LOG_WARNING, GF_LOG_DASH, ("[Dasher] Free %s\n", inband_event_desc->scheme_id_uri))
     if (inband_event_desc->scheme_id_uri) gf_free(inband_event_desc->scheme_id_uri);
     if (inband_event_desc->value) gf_free(inband_event_desc->value);
     gf_free(item);
@@ -1351,7 +1352,7 @@ void gf_mpd_adaptation_set_free(void *_item)
 	gf_mpd_del_list(ptr->rating, gf_mpd_descriptor_free, 0);
 	gf_mpd_del_list(ptr->viewpoint, gf_mpd_descriptor_free, 0);
 	gf_mpd_del_list(ptr->content_component, gf_mpd_content_component_free, 0);
-    gf_mpd_del_list(ptr->inband_event, gf_mpd_inband_event_free, 0);
+    if (ptr->inband_event) gf_mpd_del_list(ptr->inband_event, gf_mpd_inband_event_free, 0);
 	if (ptr->segment_base) gf_mpd_segment_base_free(ptr->segment_base);
 	if (ptr->segment_list) gf_mpd_segment_list_free(ptr->segment_list);
 	if (ptr->segment_template) gf_mpd_segment_template_free(ptr->segment_template);

--- a/src/media_tools/mpd.c
+++ b/src/media_tools/mpd.c
@@ -573,6 +573,21 @@ static GF_Err gf_mpd_parse_content_component(GF_List *comps, GF_XMLNode *root)
 	return GF_OK;
 }
 
+static GF_Err gf_mpd_parse_inband_event(GF_List *comps, GF_XMLNode *root) {
+    u32 i;
+    GF_XMLAttribute *att;
+    GF_MPD_Inband_Event *ibe;
+    GF_SAFEALLOC(ibe, GF_MPD_Inband_Event);
+    if (!ibe) return GF_OUT_OF_MEM;
+    i = 0;
+    while ((att = gf_list_enum(root->attributes, &i))) {
+        if (!strcmp(att->name, "schemeIdUri")) ibe->scheme_id_uri = gf_strdup(att->value);
+        else if (!strcmp(att->name, "value")) ibe->value = gf_strdup(att->value);
+
+    }
+    gf_list_add(comps, ibe);
+    return GF_OK;
+}
 
 static GF_Err gf_mpd_parse_descriptor_ex(GF_List *container, GF_MPD_Descriptor **out_ptr, GF_XMLNode *root)
 {
@@ -895,6 +910,7 @@ GF_MPD_AdaptationSet *gf_mpd_adaptation_set_new() {
 	set->rating = gf_list_new();
 	set->viewpoint = gf_list_new();
 	set->content_component = gf_list_new();
+    set->inband_event = gf_list_new();
 	set->base_URLs = gf_list_new();
 	set->representations = gf_list_new();
 	GF_SAFEALLOC(set->par, GF_MPD_Fractional);
@@ -975,8 +991,10 @@ static GF_Err gf_mpd_parse_adaptation_set(GF_MPD *mpd, GF_List *container, GF_XM
 		else if (!strcmp(child->name, "ContentComponent")) {
 			e = gf_mpd_parse_content_component(set->content_component, child);
 			if (e) return e;
-		}
-		else if (!strcmp(child->name, "SegmentBase")) {
+		} else if(!strcmp(child->name, "InbandEventStream")) {
+            e = gf_mpd_parse_inband_event(set->inband_event, child);
+            if (e) return e;
+        } else if (!strcmp(child->name, "SegmentBase")) {
 			set->segment_base = gf_mpd_parse_segment_base(mpd, child);
 		}
 		else if (!strcmp(child->name, "SegmentList")) {
@@ -1228,6 +1246,13 @@ void gf_mpd_content_component_free(void *item)
 	gf_free(item);
 }
 
+void gf_mpd_inband_event_free(void *item) {
+    GF_MPD_Inband_Event *inband_event_desc = (GF_MPD_Inband_Event *) item;
+    if (inband_event_desc->scheme_id_uri) gf_free(inband_event_desc->scheme_id_uri);
+    if (inband_event_desc->value) gf_free(inband_event_desc->value);
+    gf_free(item);
+}
+
 void gf_mpd_producer_reftime_free(void *item)
 {
 	GF_MPD_ProducerReferenceTime *pref=(GF_MPD_ProducerReferenceTime*) item;
@@ -1326,6 +1351,7 @@ void gf_mpd_adaptation_set_free(void *_item)
 	gf_mpd_del_list(ptr->rating, gf_mpd_descriptor_free, 0);
 	gf_mpd_del_list(ptr->viewpoint, gf_mpd_descriptor_free, 0);
 	gf_mpd_del_list(ptr->content_component, gf_mpd_content_component_free, 0);
+    gf_mpd_del_list(ptr->inband_event, gf_mpd_inband_event_free, 0);
 	if (ptr->segment_base) gf_mpd_segment_base_free(ptr->segment_base);
 	if (ptr->segment_list) gf_mpd_segment_list_free(ptr->segment_list);
 	if (ptr->segment_template) gf_mpd_segment_template_free(ptr->segment_template);
@@ -1620,6 +1646,7 @@ static GF_Err gf_m3u8_fill_mpd_struct(MasterPlaylist *pl, const char *m3u8_file,
 		set->rating = gf_list_new();
 		set->viewpoint = gf_list_new();
 		set->content_component = gf_list_new();
+        set->inband_event = gf_list_new();
 		set->base_URLs = gf_list_new();
 		set->representations = gf_list_new();
 		/*assign default ID and group*/
@@ -3058,6 +3085,16 @@ static void gf_mpd_print_content_component(FILE *out, GF_List *content_component
 	}
 }
 
+static void gf_mpd_print_inband_event(FILE *out, GF_List *inband_event, s32 indent) {
+    u32 i = 0;
+    GF_MPD_Inband_Event *ibe;
+    while ((ibe = gf_list_enum(inband_event, &i))) {
+        gf_mpd_nl(out, indent);
+        gf_fprintf(out, "<InbandEventStream schemeIdUri=\"%s\" value=\"%s\"/>", ibe->scheme_id_uri, ibe->value);
+        gf_mpd_lf(out, indent);
+    }
+}
+
 static void gf_mpd_print_common_attributes(FILE *out, GF_MPD_CommonAttributes *ca)
 {
 	if (ca->profiles) {
@@ -3393,6 +3430,7 @@ static void gf_mpd_print_adaptation_set(GF_MPD_AdaptationSet *as, FILE *out, Boo
 	gf_mpd_print_descriptors(out, as->rating, "Rating", indent+1, as->x_children, &child_idx);
 	gf_mpd_print_descriptors(out, as->viewpoint, "Viewpoint", indent+1, as->x_children, &child_idx);
 	gf_mpd_print_content_component(out, as->content_component, indent+1);
+    gf_mpd_print_inband_event(out, as->inband_event, indent + 1);
 
 	if (as->segment_base) {
 		gf_mpd_extensible_print_nodes(out, as->x_children, indent, &child_idx, GF_FALSE);
@@ -5524,6 +5562,7 @@ static GF_Err smooth_parse_stream_index(GF_MPD *mpd, GF_List *container, GF_XMLN
     set->rating = gf_list_new();
     set->viewpoint = gf_list_new();
     set->content_component = gf_list_new();
+    set->inband_event = gf_list_new();
     set->base_URLs = gf_list_new();
     set->representations = gf_list_new();
     set->segment_alignment = GF_TRUE;

--- a/src/media_tools/mpd.c
+++ b/src/media_tools/mpd.c
@@ -1248,7 +1248,6 @@ void gf_mpd_content_component_free(void *item)
 
 void gf_mpd_inband_event_free(void *item) {
     GF_MPD_Inband_Event *inband_event_desc = (GF_MPD_Inband_Event *) item;
-	GF_LOG(GF_LOG_WARNING, GF_LOG_DASH, ("[Dasher] Free %s\n", inband_event_desc->scheme_id_uri))
     if (inband_event_desc->scheme_id_uri) gf_free(inband_event_desc->scheme_id_uri);
     if (inband_event_desc->value) gf_free(inband_event_desc->value);
     gf_free(item);


### PR DESCRIPTION
Previously, the TS demuxer only supported attaching one ID3 event per audio packet out from the demuxer filter. There are cases where one ID3 tag is insufficient.

This PR:

* Refactors the serialization/deserialization of ID3 tags into its own `id3.h/c` module.
* The `dmx_m2ts` now packages the ID3 events from ID3 PIC as a linked list of serialized tags.
* The `mux_isom` process the list of ID3 events and package them into the segment.