### PR TITLE
VID-7463: handle multiple ID3 tags in a single audio packet

### DIFF
--- a/build/android/jni/libgpac/Android.mk
+++ b/build/android/jni/libgpac/Android.mk
@@ -333,6 +333,7 @@ LOCAL_SRC_FILES := \
 	../../../../src/media_tools/dsmcc.c \
 	../../../../src/media_tools/dvb_mpe.c \
 	../../../../src/media_tools/gpac_ogg.c \
+	../../../../src/media_tools/id3.c \
 	../../../../src/media_tools/img.c \
 	../../../../src/media_tools/isom_hinter.c \
 	../../../../src/media_tools/isom_tools.c \

--- a/include/gpac/id3.h
+++ b/include/gpac/id3.h
@@ -1,0 +1,44 @@
+
+#ifndef _GF_ID3_H_
+#define _GF_ID3_H_
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <gpac/bitstream.h>
+
+// First 36 bytes of a Nielsen ID3 tag: "ID3\x04\x00 \x00\x00\x02\x05PRIV\x00\x00\x01{\x00\x00www.nielsen.com/"
+static const u32 NIELSEN_ID3_TAG_PREFIX_LEN = 36;
+static const u8 NIELSEN_ID3_TAG_PREFIX[] = {0x49, 0x44, 0x33, 0x04, 0x00, 0x20,
+											0x00, 0x00, 0x02, 0x05, 0x50, 0x52,
+											0x49, 0x56, 0x00, 0x00, 0x01, 0x7B,
+											0x00, 0x00, 0x77, 0x77, 0x77, 0x2E,
+											0x6E, 0x69, 0x65, 0x6C, 0x73, 0x65,
+											0x6E, 0x2E, 0x63, 0x6F, 0x6D, 0x2F};
+
+static const char *ID3_PROP_SCHEME_URI = "https://aomedia.org/emsg/ID3";
+static const char *ID3_PROP_VALUE_URI_NIELSEN = "www.nielsen.com:id3:v1";
+static const char *ID3_PROP_VALUE_URI_DEFAULT = "https://aomedia.org/emsg/ID3";
+
+typedef struct {
+    u32 timescale;
+    u64 pts;
+    char* scheme_uri;
+    char* value_uri;
+    u32 data_length;
+    u8* data;
+} GF_ID3_TAG;
+
+GF_Err id3_tag_new(GF_ID3_TAG *tag, u32 timescale, u64 pts, u8 *data, u32 data_length);
+
+void id3_tag_free(GF_ID3_TAG *tag);
+
+void id3_to_bitstream(GF_ID3_TAG *tag, GF_BitStream *bs);
+
+void id3_from_bitstream(GF_ID3_TAG *tag, GF_BitStream *bs);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _GF_ID3_H_

--- a/include/gpac/id3.h
+++ b/include/gpac/id3.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 #include <gpac/bitstream.h>
+#include <gpac/list.h>
 
 typedef struct {
     u32 timescale;
@@ -23,6 +24,8 @@ GF_Err gf_id3_tag_new(GF_ID3_TAG *tag, u32 timescale, u64 pts, u8 *data, u32 dat
 void gf_id3_tag_free(GF_ID3_TAG *tag);
 
 GF_Err gf_id3_to_bitstream(GF_ID3_TAG *tag, GF_BitStream *bs);
+
+GF_Err gf_id3_list_to_bitstream(GF_List *tag_list, GF_BitStream *bs);
 
 GF_Err gf_id3_from_bitstream(GF_ID3_TAG *tag, GF_BitStream *bs);
 

--- a/include/gpac/id3.h
+++ b/include/gpac/id3.h
@@ -7,35 +7,24 @@ extern "C" {
 
 #include <gpac/bitstream.h>
 
-// First 36 bytes of a Nielsen ID3 tag: "ID3\x04\x00 \x00\x00\x02\x05PRIV\x00\x00\x01{\x00\x00www.nielsen.com/"
-static const u32 NIELSEN_ID3_TAG_PREFIX_LEN = 36;
-static const u8 NIELSEN_ID3_TAG_PREFIX[] = {0x49, 0x44, 0x33, 0x04, 0x00, 0x20,
-											0x00, 0x00, 0x02, 0x05, 0x50, 0x52,
-											0x49, 0x56, 0x00, 0x00, 0x01, 0x7B,
-											0x00, 0x00, 0x77, 0x77, 0x77, 0x2E,
-											0x6E, 0x69, 0x65, 0x6C, 0x73, 0x65,
-											0x6E, 0x2E, 0x63, 0x6F, 0x6D, 0x2F};
-
-static const char *ID3_PROP_SCHEME_URI = "https://aomedia.org/emsg/ID3";
-static const char *ID3_PROP_VALUE_URI_NIELSEN = "www.nielsen.com:id3:v1";
-static const char *ID3_PROP_VALUE_URI_DEFAULT = "https://aomedia.org/emsg/ID3";
-
 typedef struct {
     u32 timescale;
     u64 pts;
+    u32 scheme_uri_length;
     char* scheme_uri;
+    u32 value_uri_length;
     char* value_uri;
     u32 data_length;
     u8* data;
 } GF_ID3_TAG;
 
-GF_Err id3_tag_new(GF_ID3_TAG *tag, u32 timescale, u64 pts, u8 *data, u32 data_length);
+GF_Err gf_id3_tag_new(GF_ID3_TAG *tag, u32 timescale, u64 pts, u8 *data, u32 data_length);
 
-void id3_tag_free(GF_ID3_TAG *tag);
+void gf_id3_tag_free(GF_ID3_TAG *tag);
 
-void id3_to_bitstream(GF_ID3_TAG *tag, GF_BitStream *bs);
+GF_Err gf_id3_to_bitstream(GF_ID3_TAG *tag, GF_BitStream *bs);
 
-void id3_from_bitstream(GF_ID3_TAG *tag, GF_BitStream *bs);
+GF_Err gf_id3_from_bitstream(GF_ID3_TAG *tag, GF_BitStream *bs);
 
 #ifdef __cplusplus
 }

--- a/src/Makefile
+++ b/src/Makefile
@@ -91,7 +91,7 @@ endif
 LIBGPAC_EVG=evg/ftgrays.o evg/raster3d.o evg/raster_565.o evg/raster_argb.o evg/raster_rgb.o evg/raster_yuv.o evg/stencil.o evg/surface.o
 
 ## libgpac objects gathering: src/media tools
-LIBGPAC_MEDIATOOLS=media_tools/isom_tools.o media_tools/dash_segmenter.o media_tools/av_parsers.o media_tools/route_dmx.o
+LIBGPAC_MEDIATOOLS=media_tools/isom_tools.o media_tools/dash_segmenter.o media_tools/av_parsers.o media_tools/route_dmx.o media_tools/id3.o
 
 ifeq ($(DISABLE_AV_PARSERS),no)
 LIBGPAC_MEDIATOOLS+=media_tools/img.o

--- a/src/filters/dmx_m2ts.c
+++ b/src/filters/dmx_m2ts.c
@@ -32,19 +32,20 @@
 #include <gpac/mpegts.h>
 #include <gpac/thread.h>
 #include <gpac/internal/media_dev.h>
+#include <gpac/id3.h>
 
-// First 36 bytes of a Nielsen ID3 tag: "ID3\x04\x00 \x00\x00\x02\x05PRIV\x00\x00\x01{\x00\x00www.nielsen.com/"
-static const u32 NIELSEN_ID3_TAG_PREFIX_LEN = 36;
-static const u8 NIELSEN_ID3_TAG_PREFIX[] = {0x49, 0x44, 0x33, 0x04, 0x00, 0x20,
-											0x00, 0x00, 0x02, 0x05, 0x50, 0x52,
-											0x49, 0x56, 0x00, 0x00, 0x01, 0x7B,
-											0x00, 0x00, 0x77, 0x77, 0x77, 0x2E,
-											0x6E, 0x69, 0x65, 0x6C, 0x73, 0x65,
-											0x6E, 0x2E, 0x63, 0x6F, 0x6D, 0x2F};
+// // First 36 bytes of a Nielsen ID3 tag: "ID3\x04\x00 \x00\x00\x02\x05PRIV\x00\x00\x01{\x00\x00www.nielsen.com/"
+// static const u32 NIELSEN_ID3_TAG_PREFIX_LEN = 36;
+// static const u8 NIELSEN_ID3_TAG_PREFIX[] = {0x49, 0x44, 0x33, 0x04, 0x00, 0x20,
+// 											0x00, 0x00, 0x02, 0x05, 0x50, 0x52,
+// 											0x49, 0x56, 0x00, 0x00, 0x01, 0x7B,
+// 											0x00, 0x00, 0x77, 0x77, 0x77, 0x2E,
+// 											0x6E, 0x69, 0x65, 0x6C, 0x73, 0x65,
+// 											0x6E, 0x2E, 0x63, 0x6F, 0x6D, 0x2F};
 
-static const char *ID3_PROP_SCHEME_URI = "https://aomedia.org/emsg/ID3";
-static const char *ID3_PROP_VALUE_URI_NIELSEN = "www.nielsen.com:id3:v1";
-static const char *ID3_PROP_VALUE_URI_DEFAULT = "https://aomedia.org/emsg/ID3";
+// static const char *ID3_PROP_SCHEME_URI = "https://aomedia.org/emsg/ID3";
+// static const char *ID3_PROP_VALUE_URI_NIELSEN = "www.nielsen.com:id3:v1";
+// static const char *ID3_PROP_VALUE_URI_DEFAULT = "https://aomedia.org/emsg/ID3";
 
 typedef struct {
 	char *fragment;
@@ -1204,35 +1205,21 @@ static void m2tsdmx_on_event(GF_M2TS_Demuxer *ts, u32 evt_type, void *param)
 			if (!t) break;
 			t->type = M2TS_ID3;
 
-			u32 value_uri_len = 0;
-			const char *value_uri = NULL;
-
-			// test if the data is a Nielsen ID3 tag
-			if (memcmp(pck->data, NIELSEN_ID3_TAG_PREFIX, NIELSEN_ID3_TAG_PREFIX_LEN) == 0)
+			GF_ID3_TAG id3_tag;
+			if (gf_id3_tag_new(&id3_tag, 90000, pck->PTS, pck->data, pck->data_len) != GF_OK)
 			{
-				value_uri_len = strlen(ID3_PROP_VALUE_URI_NIELSEN) + 1; // plus null character
-				value_uri = ID3_PROP_VALUE_URI_NIELSEN;
+				GF_LOG(GF_LOG_ERROR, GF_LOG_CONTAINER, ("[M2TSDMx] Error creating ID3 tag"));
+				break;
 			}
-			else
-			{
-				value_uri_len = strlen(ID3_PROP_VALUE_URI_DEFAULT) + 1; // plus null character
-				value_uri = ID3_PROP_VALUE_URI_DEFAULT;
-			}
-
-			const u32 id3_scheme_uri_len = (u32)strlen(ID3_PROP_SCHEME_URI) + 1; // plus null character
 
 			bs = gf_bs_new(NULL, 0, GF_BITSTREAM_WRITE);
-			gf_bs_write_u32(bs, 90000);												   // timescale
-			gf_bs_write_u64(bs, pck->PTS);											   // pts
-			gf_bs_write_u32(bs, id3_scheme_uri_len);								   // scheme URI length
-			gf_bs_write_data(bs, (const u8 *)ID3_PROP_SCHEME_URI, id3_scheme_uri_len); // scheme URI
-			gf_bs_write_u32(bs, value_uri_len);										   // value URI length
-			gf_bs_write_data(bs, (const u8 *)value_uri, value_uri_len);				   // value URI
-			gf_bs_write_u32(bs, pck->data_len);										   // data length (bytes)
-			gf_bs_write_data(bs, pck->data, pck->data_len);							   // data
+			if (gf_id3_to_bitstream(&id3_tag, bs) != GF_OK) {
+				GF_LOG(GF_LOG_ERROR, GF_LOG_CONTAINER, ("[M2TSDMx] Error serializing ID3 property"));
+			}
 
 			gf_bs_get_content(bs, &t->data, &t->len);
 			gf_bs_del(bs);
+			gf_id3_tag_free(&id3_tag);
 
 			if (!es->props) {
 				es->props = gf_list_new();

--- a/src/media_tools/id3.c
+++ b/src/media_tools/id3.c
@@ -15,6 +15,10 @@ static const char *ID3_PROP_VALUE_URI_DEFAULT = "https://aomedia.org/emsg/ID3";
 
 GF_Err gf_id3_tag_new(GF_ID3_TAG *tag, u32 timescale, u64 pts, u8 *data, u32 data_length)
 {
+    if (!tag) {
+        return GF_BAD_PARAM;
+    }
+
     if (data == NULL || data_length == 0) {
         return GF_BAD_PARAM;
     }
@@ -93,6 +97,25 @@ GF_Err gf_id3_to_bitstream(GF_ID3_TAG *tag, GF_BitStream *bs)
     }
 
     return GF_OK;
+}
+
+GF_Err gf_id3_list_to_bitstream(GF_List *tag_list, GF_BitStream *bs) {
+
+    GF_Err err = GF_OK;
+
+    // first, write the number of tags
+    u32 id3_count = gf_list_count(tag_list);
+    gf_bs_write_u32(bs, id3_count);
+
+    for (u32 i = 0; i < id3_count; ++i) {
+        GF_ID3_TAG *tag = gf_list_get(tag_list, i);
+        err = gf_id3_to_bitstream(tag, bs);
+        if (err != GF_OK) {
+            return err;
+        }
+    }
+
+    return err;
 }
 
 GF_Err gf_id3_from_bitstream(GF_ID3_TAG *tag, GF_BitStream *bs)

--- a/src/media_tools/id3.c
+++ b/src/media_tools/id3.c
@@ -1,0 +1,72 @@
+#include <gpac/id3.h>
+
+GF_Err id3_tag_new(GF_ID3_TAG *tag, u32 timescale, u64 pts, u8 *data, u32 data_length)
+{
+    if (data == NULL || data_length == 0) {
+        return GF_BAD_PARAM;
+    }
+
+    tag->timescale = timescale;
+    tag->pts = pts;
+    tag->scheme_uri = gf_strdup(ID3_PROP_SCHEME_URI);
+
+    // test if the data is a Nielsen ID3 tag
+    if (memcmp(data, NIELSEN_ID3_TAG_PREFIX, NIELSEN_ID3_TAG_PREFIX_LEN) == 0)
+    {
+        tag->value_uri = gf_strdup(ID3_PROP_VALUE_URI_NIELSEN);
+    }
+    else
+    {
+        tag->value_uri = gf_strdup(ID3_PROP_VALUE_URI_DEFAULT);
+    }
+
+    tag->data = gf_malloc(data_length);
+    memcpy(tag->data, data, data_length);
+
+    return GF_OK;
+}
+
+void id3_tag_free(GF_ID3_TAG *tag)
+{
+    if (!tag) {
+        return;
+    }
+
+    if (tag->scheme_uri) {
+        gf_free(tag->scheme_uri);
+        tag->scheme_uri = NULL;
+    }
+
+    if (tag->value_uri) {
+        gf_free(tag->value_uri);
+        tag->value_uri = NULL;
+    }
+
+    if (tag->data) {
+        gf_free(tag->data);
+        tag->data = NULL;
+    }
+}
+
+void id3_to_bitstream(GF_ID3_TAG *tag, GF_BitStream *bs)
+{
+    gf_bs_write_u32(bs, tag->timescale);
+    gf_bs_write_u64(bs, tag->pts);
+
+    u32 scheme_uri_len = strlen(tag->scheme_uri) + 1; // plus null character
+    u32 value_uri_len = strlen(tag->value_uri) + 1;   // plus null character
+
+    gf_bs_write_u32(bs, scheme_uri_len);
+    gf_bs_write_data(bs, (const u8 *)tag->scheme_uri, scheme_uri_len);
+
+    gf_bs_write_u32(bs, value_uri_len);
+    gf_bs_write_data(bs, (const u8 *)tag->value_uri, value_uri_len);
+
+    gf_bs_write_u32(bs, tag->data_length);
+    gf_bs_write_data(bs, tag->data, tag->data_length);
+}
+
+void id3_from_bitstream(GF_ID3_TAG *tag, GF_BitStream *bs)
+{
+    // TODO: aqui voy
+}

--- a/src/media_tools/id3.c
+++ b/src/media_tools/id3.c
@@ -1,6 +1,19 @@
 #include <gpac/id3.h>
 
-GF_Err id3_tag_new(GF_ID3_TAG *tag, u32 timescale, u64 pts, u8 *data, u32 data_length)
+// First 36 bytes of a Nielsen ID3 tag: "ID3\x04\x00 \x00\x00\x02\x05PRIV\x00\x00\x01{\x00\x00www.nielsen.com/"
+static const u32 NIELSEN_ID3_TAG_PREFIX_LEN = 36;
+static const u8 NIELSEN_ID3_TAG_PREFIX[] = {0x49, 0x44, 0x33, 0x04, 0x00, 0x20,
+                                            0x00, 0x00, 0x02, 0x05, 0x50, 0x52,
+                                            0x49, 0x56, 0x00, 0x00, 0x01, 0x7B,
+                                            0x00, 0x00, 0x77, 0x77, 0x77, 0x2E,
+                                            0x6E, 0x69, 0x65, 0x6C, 0x73, 0x65,
+                                            0x6E, 0x2E, 0x63, 0x6F, 0x6D, 0x2F};
+
+static const char *ID3_PROP_SCHEME_URI = "https://aomedia.org/emsg/ID3";
+static const char *ID3_PROP_VALUE_URI_NIELSEN = "www.nielsen.com:id3:v1";
+static const char *ID3_PROP_VALUE_URI_DEFAULT = "https://aomedia.org/emsg/ID3";
+
+GF_Err gf_id3_tag_new(GF_ID3_TAG *tag, u32 timescale, u64 pts, u8 *data, u32 data_length)
 {
     if (data == NULL || data_length == 0) {
         return GF_BAD_PARAM;
@@ -9,6 +22,7 @@ GF_Err id3_tag_new(GF_ID3_TAG *tag, u32 timescale, u64 pts, u8 *data, u32 data_l
     tag->timescale = timescale;
     tag->pts = pts;
     tag->scheme_uri = gf_strdup(ID3_PROP_SCHEME_URI);
+    tag->scheme_uri_length = strlen(ID3_PROP_SCHEME_URI) + 1; // plus null character
 
     // test if the data is a Nielsen ID3 tag
     if (memcmp(data, NIELSEN_ID3_TAG_PREFIX, NIELSEN_ID3_TAG_PREFIX_LEN) == 0)
@@ -20,13 +34,16 @@ GF_Err id3_tag_new(GF_ID3_TAG *tag, u32 timescale, u64 pts, u8 *data, u32 data_l
         tag->value_uri = gf_strdup(ID3_PROP_VALUE_URI_DEFAULT);
     }
 
+    tag->value_uri_length = strlen(tag->value_uri) + 1; // plus null character
+
+    tag->data_length = data_length;
     tag->data = gf_malloc(data_length);
     memcpy(tag->data, data, data_length);
 
     return GF_OK;
 }
 
-void id3_tag_free(GF_ID3_TAG *tag)
+void gf_id3_tag_free(GF_ID3_TAG *tag)
 {
     if (!tag) {
         return;
@@ -48,25 +65,65 @@ void id3_tag_free(GF_ID3_TAG *tag)
     }
 }
 
-void id3_to_bitstream(GF_ID3_TAG *tag, GF_BitStream *bs)
+GF_Err gf_id3_to_bitstream(GF_ID3_TAG *tag, GF_BitStream *bs)
 {
+    if (!tag || !bs) {
+        return GF_BAD_PARAM;
+    }
+
     gf_bs_write_u32(bs, tag->timescale);
     gf_bs_write_u64(bs, tag->pts);
 
-    u32 scheme_uri_len = strlen(tag->scheme_uri) + 1; // plus null character
-    u32 value_uri_len = strlen(tag->value_uri) + 1;   // plus null character
+    gf_bs_write_u32(bs, tag->scheme_uri_length);
+    u32 bytes_read = gf_bs_write_data(bs, (const u8 *)tag->scheme_uri, tag->scheme_uri_length);
+    if (bytes_read != tag->scheme_uri_length) {
+        return GF_IO_ERR;
+    }
 
-    gf_bs_write_u32(bs, scheme_uri_len);
-    gf_bs_write_data(bs, (const u8 *)tag->scheme_uri, scheme_uri_len);
-
-    gf_bs_write_u32(bs, value_uri_len);
-    gf_bs_write_data(bs, (const u8 *)tag->value_uri, value_uri_len);
+    gf_bs_write_u32(bs, tag->value_uri_length);
+    bytes_read = gf_bs_write_data(bs, (const u8 *)tag->value_uri, tag->value_uri_length);
+    if (bytes_read != tag->value_uri_length) {
+        return GF_IO_ERR;
+    }
 
     gf_bs_write_u32(bs, tag->data_length);
-    gf_bs_write_data(bs, tag->data, tag->data_length);
+    bytes_read = gf_bs_write_data(bs, tag->data, tag->data_length);
+    if (bytes_read != tag->data_length) {
+        return GF_IO_ERR;
+    }
+
+    return GF_OK;
 }
 
-void id3_from_bitstream(GF_ID3_TAG *tag, GF_BitStream *bs)
+GF_Err gf_id3_from_bitstream(GF_ID3_TAG *tag, GF_BitStream *bs)
 {
-    // TODO: aqui voy
+    if (!tag || !bs) {
+        return GF_BAD_PARAM;
+    }
+
+    tag->timescale = gf_bs_read_u32(bs);
+    tag->pts = gf_bs_read_u64(bs);
+
+    tag->scheme_uri_length = gf_bs_read_u32(bs);
+    tag->scheme_uri = gf_malloc(tag->scheme_uri_length);
+    u32 bytes_read = gf_bs_read_data(bs, tag->scheme_uri, tag->scheme_uri_length);
+    if (bytes_read != tag->scheme_uri_length) {
+        return GF_IO_ERR;
+    }
+
+    tag->value_uri_length = gf_bs_read_u32(bs);
+    tag->value_uri = gf_malloc(tag->value_uri_length);
+    bytes_read = gf_bs_read_data(bs, tag->value_uri, tag->value_uri_length);
+    if (bytes_read != tag->value_uri_length) {
+        return GF_IO_ERR;
+    }
+
+    tag->data_length = gf_bs_read_u32(bs);
+    tag->data = gf_malloc(tag->data_length);
+    bytes_read = gf_bs_read_data(bs, tag->data, tag->data_length);
+    if (bytes_read != tag->data_length) {
+        return GF_IO_ERR;
+    }
+
+    return GF_OK;
 }


### PR DESCRIPTION
Previously, the TS demuxer only supported attaching one ID3 event per audio packet out from the demuxer filter. There are cases where one ID3 tag is insufficient.

The image below shows the packaging of a TS file containing 2 ID3 PIDs, each producing tags at 25Hz. GPAC only packaged half of the tags (corresponding to `metadata 22222`

![image](https://github.com/user-attachments/assets/4598a860-efed-477a-9ac2-3fd9fa45e032)

This PR:

* Refactors the serialization/deserialization of ID3 tags into its own `id3.h/c` module.
* The `dmx_m2ts` now packages the ID3 events from ID3 PIC as a linked list of serialized tags.
* The `mux_isom` process the list of ID3 events and package them into the segment.

With these changes, GPAC can package all the ID3 tags correctly (50 tags per 1s audio segment)

![image](https://github.com/user-attachments/assets/7cb12d1b-dcc7-4162-a480-40ddaa56188f)
 